### PR TITLE
Fix API build

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -4,16 +4,6 @@
 # list see the documentation:
 # https://www.sphinx-doc.org/en/master/usage/configuration.html
 
-# -- Path setup --------------------------------------------------------------
-
-# If extensions (or modules to document with autodoc) are in another directory,
-# add these directories to sys.path here. If the directory is relative to the
-# documentation root, use os.path.abspath to make it absolute, like shown here.
-#
-import os
-import sys
-sys.path.insert(0, os.path.abspath('../../src'))
-autodoc_mock_imports = ["hist"]
 
 
 # -- Project information -----------------------------------------------------

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -17,4 +17,4 @@ python:
   install:
      - requirements: doc/requirements.txt
      - method: pip
-        path: .
+       path: .

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -16,6 +16,5 @@ python:
   version: 3.7
   install:
      - requirements: doc/requirements.txt
-
-submodules:
-  exclude: all
+     - method: pip
+        path: .


### PR DESCRIPTION
This is injecting a dummy "hist" object which cannot be documented. Simply requiring the package to be installed first fixes the problem this was trying to solve. Should fix #2.